### PR TITLE
Update Android compile & jvm version for audio_streamer

### DIFF
--- a/packages/audio_streamer/android/build.gradle
+++ b/packages/audio_streamer/android/build.gradle
@@ -29,12 +29,12 @@ android {
     ndkVersion flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '21'
     }
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
## Summary
- update `compileOptions` and `kotlinOptions` in `audio_streamer` plugin

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686071c011e88321a8cf15541eb8649a