### PR TITLE
Update noise_meter for Java 21

### DIFF
--- a/packages/noise_meter/example/android/app/build.gradle
+++ b/packages/noise_meter/example/android/app/build.gradle
@@ -27,8 +27,8 @@ android {
     namespace "com.noise_meter.example"
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     sourceSets {
@@ -36,7 +36,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '21'
     }
 
     lintOptions {

--- a/packages/noise_meter/example/android/build.gradle
+++ b/packages/noise_meter/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '2.0.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
## Summary
- bump Kotlin gradle plugin and Android gradle plugin
- target Java 21 byte-code for example app

## Testing
- `dart test` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863237e228483218072c54fa3f4e000