### PR TITLE
Use local audio streamer in noise_meter

### DIFF
--- a/packages/noise_meter/CHANGELOG.md
+++ b/packages/noise_meter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.1
+
+- use local `audio_streamer` package
+
 ## 5.1.0
 
 - upgrading gradle version

--- a/packages/noise_meter/pubspec.yaml
+++ b/packages/noise_meter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: noise_meter
 description: A Flutter plugin for collecting noise from the phone's microphone.
-version: 5.1.0
+version: 5.1.1
 homepage: https://github.com/cph-cachet/flutter-plugins/tree/master/packages/noise_meter
 
 environment:
@@ -10,9 +10,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  audio_streamer: ^4.0.0
+  audio_streamer:
+    path: ../audio_streamer
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  test: any
+  pubspec_parse: any
   flutter_lints: any

--- a/packages/noise_meter/test/pubspec_dependency_test.dart
+++ b/packages/noise_meter/test/pubspec_dependency_test.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('uses local audio_streamer dependency', () {
+    final pubspecContent = File('pubspec.yaml').readAsStringSync();
+    final pubspec = Pubspec.parse(pubspecContent);
+    final dependency = pubspec.dependencies['audio_streamer'];
+    expect(dependency, isA<PathDependency>());
+    final pathDep = dependency as PathDependency;
+    // The path should point to the sibling audio_streamer package
+    expect(pathDep.path, '../audio_streamer');
+  });
+}


### PR DESCRIPTION
## Summary
- add test to ensure noise_meter depends on the repository audio_streamer
- point noise_meter to the local audio_streamer package
- document the dependency change

## Testing
- `dart test packages/noise_meter/test/pubspec_dependency_test.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686378dc19f4832186ee24959f7929c7