### PR TITLE
Use local audio_streamer in noise_meter

### DIFF
--- a/packages/noise_meter/CHANGELOG.md
+++ b/packages/noise_meter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.2
+
+- use local `audio_streamer` package
+
 ## 5.1.1
 
 - update Android example to Java and Kotlin 21

--- a/packages/noise_meter/pubspec.yaml
+++ b/packages/noise_meter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: noise_meter
 description: A Flutter plugin for collecting noise from the phone's microphone.
-version: 5.1.1
+version: 5.1.2
 homepage: https://github.com/cph-cachet/flutter-plugins/tree/master/packages/noise_meter
 
 environment:
@@ -10,7 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  audio_streamer: ^4.0.0
+  audio_streamer:
+    path: ../audio_streamer
 
 dev_dependencies:
   flutter_test:

--- a/packages/noise_meter/test/noise_reading_test.dart
+++ b/packages/noise_meter/test/noise_reading_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:noise_meter/noise_meter.dart';
+
+void main() {
+  test('NoiseReading computes correct decibel values', () {
+    final reading = NoiseReading([0.1, 0.7]);
+    expect(reading.maxDecibel, closeTo(87.21096, 0.001));
+    expect(reading.meanDecibel, closeTo(82.35020, 0.001));
+  });
+}


### PR DESCRIPTION
## Summary
- update noise_meter to reference the audio_streamer package via a path
- bump noise_meter version to 5.1.2
- document the change in CHANGELOG
- add a small test for NoiseReading

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68637b20392c8321b9fecd59c065d6ab