### PR TITLE
Update noise_meter example for Java 21

### DIFF
--- a/packages/noise_meter/CHANGELOG.md
+++ b/packages/noise_meter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.1
+
+- compile Java and Kotlin sources to bytecode level 21
+
 ## 5.1.0
 
 - upgrading gradle version

--- a/packages/noise_meter/example/android/app/build.gradle
+++ b/packages/noise_meter/example/android/app/build.gradle
@@ -27,8 +27,8 @@ android {
     namespace "com.noise_meter.example"
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     sourceSets {
@@ -36,7 +36,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '21'
     }
 
     lintOptions {

--- a/packages/noise_meter/example/android/build.gradle
+++ b/packages/noise_meter/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '2.0.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/noise_meter/pubspec.yaml
+++ b/packages/noise_meter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: noise_meter
 description: A Flutter plugin for collecting noise from the phone's microphone.
-version: 5.1.0
+version: 5.1.1
 homepage: https://github.com/cph-cachet/flutter-plugins/tree/master/packages/noise_meter
 
 environment:


### PR DESCRIPTION
## Summary
- update Gradle buildscript in `noise_meter` example to use AGP 8.2.1 and Kotlin 2.0
- compile Java and Kotlin to bytecode level 21
- document bytecode upgrade in `noise_meter` changelog

## Testing
- `flutter test` *(fails: `flutter: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_6863d94ecabc8321a5b11c1563137b72